### PR TITLE
Include licence and copyright info in package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -47,6 +47,8 @@ conan_basic_setup()''')
         self.copy("*.dylib",dst="lib",      src=fmilib_install_dir, keep_path=False)
         self.copy("*.lib",  dst="lib",      src=fmilib_install_dir, keep_path=False)
         self.copy("*.a",    dst="lib",      src=fmilib_install_dir, keep_path=False)
+        self.copy("LICENSE.md",                  src="src", dst="licenses", keep_path=False)
+        self.copy("FMILIB_Acknowledgements.txt", src="src", dst="licenses", keep_path=False)
 
     def package_info(self):
         if self.options.shared:


### PR DESCRIPTION
I'm hoping to take care of open-simulation-platform/cosim-cli#70 in such a way that the dependency licences get collected automatically, but that requires all dependencies to actually include them in the package.

Putting them in `licences/` inside the Conan package directory seems to be a standard convention in conan-center.