### PR TITLE
Update fmilibrary to version 2.3

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install prerequisites
         run: |
+          sudo apt-get install -y --no-install-recommends g++-8
           sudo pip3 install --upgrade setuptools pip
           sudo pip3 install conan
       - run: conan remote add osp https://osp.jfrog.io/artifactory/api/conan/conan-local --force

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,8 +3,8 @@ from conans import ConanFile, CMake, tools
 
 class FMILibraryConan(ConanFile):
     name = "fmilibrary"
-    version = "2.0.3"
-    license = "https://svn.jmodelica.org/FMILibrary/tags/2.0.3/LICENSE.md"
+    version = "2.3"
+    license = "https://github.com/modelon-community/fmi-library/blob/master/LICENSE.md"
     url = "https://github.com/kyllingstad/conan-FMILibrary"
     description = "An implementation of the FMI standard which enables FMU import in applications"
     scm = {


### PR DESCRIPTION
Updates the recipe to use  [v2.3](https://github.com/modelon-community/fmi-library/releases/tag/2.3)

### Changelog:

* Updated fmi_import_get_fmi_version to also work on unpacked FMUs.
* Bug fix: Fix compilation issue on OSX related to locale.

* Bug fix: Fix segfault during parsing of FMI1

* Bug fix: Fix build issues introduced in 2.2.1 for non-MSVC/Linux
* Bug fix: Correctly parse doubles when locale is not using decimal point, now also for FMI1

* Bug fix: Correctly parse doubles when locale is not using decimal point
* Check variability != continuous for non-Real variables

* Added missing getters for attributes defined on a variable:
  * Real: quantity, relativeQuantity, unbound
  * Integer: quantity
  * Enumeration: quantity
* fmi2_import_get_type_quantity now returns NULL for all types if 'quantity' is not specified (API documentation previously stated that an empty string would be returned for Real, Integer and Enumeration, but NULL was incorrectly returned - this means that only the API documentation is affected by this change)

* Added functions to API for determining if DefaultExperiment values are defined in the XML (typically used to check if a default value will be returned by the getters for DefaultExperiment attributes)
* Clarified that license is 3-Clause BSD


Closes #10 