### PR TITLE
Enable building with GCC 14

### DIFF
--- a/add-missing-minizip-include.patch
+++ b/add-missing-minizip-include.patch
@@ -1,0 +1,12 @@
+diff --git a/ThirdParty/Minizip/minizip/miniunz.c b/ThirdParty/Minizip/minizip/miniunz.c
+index 2264705..9d2130c 100644
+--- a/ThirdParty/Minizip/minizip/miniunz.c
++++ b/ThirdParty/Minizip/minizip/miniunz.c
+@@ -51,6 +51,7 @@
+ # include <direct.h>
+ # include <io.h>
+ #else
++# include <sys/stat.h>
+ # include <unistd.h>
+ # include <utime.h>
+ #endif

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,11 +20,15 @@ class FMILibraryConan(ConanFile):
     tool_requires = "cmake/[>=3.15]"
     generators = "CMakeDeps"
 
-    exports_sources = "build-static-c99snprintf.patch"
+    exports_sources = [
+        "add-missing-minizip-include.patch",
+        "build-static-c99snprintf.patch",
+    ]
 
     def source(self):
         git = Git(self)
         git.clone(url="https://github.com/modelon-community/fmi-library.git", target="src", args=["--branch=2.3"])
+        patch(self, base_path="src", patch_file="add-missing-minizip-include.patch")
         patch(self, base_path="src", patch_file="build-static-c99snprintf.patch")
 
     def layout(self):


### PR DESCRIPTION
When I tried to build the package with GCC 14, I got the following error:

    src/ThirdParty/Minizip/minizip/miniunz.c:141:11: error: implicit declaration of function ‘mkdir’; did you mean ‘mymkdir’? [-Wimplicit-function-declaration]

It turns out that GCC now conforms more strictly to the C standard, and some issues that were previously only warned about are now treated as errors.  `implicit-function-declaration` is one of these.  For more info, see: https://gcc.gnu.org/gcc-14/porting_to.html#implicit-function-declaration

The solution is to patch the Minizip code so that the appropriate header for `mkdir()`, which is `<sys/stat.h>`, gets included.