### PR TITLE
Patch CMakeList to have minimum version to be 3.5

### DIFF
--- a/cmake_minimum.patch
+++ b/cmake_minimum.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9efaa70..82739ab 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,7 +14,7 @@
+ # NOTE: CMake 2.8.6 is required since this is the version used in development.
+ # The script is KNOWN NOT TO WORK WITH 2.8.3 and below (ExternalProject 
+ # interface changes). CMake 2.8.4 and 2.8.5 are not tested.
+-cmake_minimum_required (VERSION 2.8.6 FATAL_ERROR)
++cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
+ 
+ # Prohibit in-source build
+ IF("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+diff --git a/Config.cmake/Minizip/CMakeLists.txt b/Config.cmake/Minizip/CMakeLists.txt
+index 9452915..d7c5d35 100644
+--- a/Config.cmake/Minizip/CMakeLists.txt
++++ b/Config.cmake/Minizip/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(minizip C)
+ 

--- a/cmake_minimum.patch
+++ b/cmake_minimum.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9efaa70..82739ab 100644
+index 9efaa70..e4fb01d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -14,7 +14,7 @@
@@ -7,17 +7,50 @@ index 9efaa70..82739ab 100644
  # The script is KNOWN NOT TO WORK WITH 2.8.3 and below (ExternalProject 
  # interface changes). CMake 2.8.4 and 2.8.5 are not tested.
 -cmake_minimum_required (VERSION 2.8.6 FATAL_ERROR)
-+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
++cmake_minimum_required (VERSION 3.10.0 FATAL_ERROR)
  
  # Prohibit in-source build
  IF("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 diff --git a/Config.cmake/Minizip/CMakeLists.txt b/Config.cmake/Minizip/CMakeLists.txt
-index 9452915..d7c5d35 100644
+index 9452915..f790916 100644
 --- a/Config.cmake/Minizip/CMakeLists.txt
 +++ b/Config.cmake/Minizip/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 2.8)
-+cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
  
  project(minizip C)
  
+diff --git a/ThirdParty/CMakeModules/UseDoxygen/CMakeLists.txt b/ThirdParty/CMakeModules/UseDoxygen/CMakeLists.txt
+index c4d06e3..49fb14b 100644
+--- a/ThirdParty/CMakeModules/UseDoxygen/CMakeLists.txt
++++ b/ThirdParty/CMakeModules/UseDoxygen/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 3.10)
+ 
+ project(UseDoxygen)
+ 
+diff --git a/ThirdParty/Expat/expat-2.1.0/CMakeLists.txt b/ThirdParty/Expat/expat-2.1.0/CMakeLists.txt
+index 0c923ba..50505df 100644
+--- a/ThirdParty/Expat/expat-2.1.0/CMakeLists.txt
++++ b/ThirdParty/Expat/expat-2.1.0/CMakeLists.txt
+@@ -3,7 +3,7 @@
+ 
+ project(expat)
+ 
+-cmake_minimum_required(VERSION 2.6)
++cmake_minimum_required(VERSION 3.10)
+ set(PACKAGE_BUGREPORT "expat-bugs@libexpat.org")
+ set(PACKAGE_NAME "expat")
+ set(PACKAGE_VERSION "2.1.0")
+diff --git a/ThirdParty/Zlib/zlib-1.2.6/CMakeLists.txt b/ThirdParty/Zlib/zlib-1.2.6/CMakeLists.txt
+index 98224b1..88fcc71 100644
+--- a/ThirdParty/Zlib/zlib-1.2.6/CMakeLists.txt
++++ b/ThirdParty/Zlib/zlib-1.2.6/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.4.4)
++cmake_minimum_required(VERSION 3.10)
+ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
+ 
+ project(zlib C)

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,6 +23,7 @@ class FMILibraryConan(ConanFile):
     exports_sources = [
         "add-missing-minizip-include.patch",
         "build-static-c99snprintf.patch",
+        "cmake_minimum.patch",
     ]
 
     def source(self):
@@ -30,6 +31,7 @@ class FMILibraryConan(ConanFile):
         git.clone(url="https://github.com/modelon-community/fmi-library.git", target="src", args=["--branch=2.3"])
         patch(self, base_path="src", patch_file="add-missing-minizip-include.patch")
         patch(self, base_path="src", patch_file="build-static-c99snprintf.patch")
+        patch(self, base_path="src", patch_file="cmake_minimum.patch")
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
CMake 4.0 deprecates cmake versions<3.5.
Patching fmilibrary to avoid build error on the latest github ubuntu images for CI/CD